### PR TITLE
Add header guards to array.h

### DIFF
--- a/hemi/array.h
+++ b/hemi/array.h
@@ -1,3 +1,6 @@
+#ifndef __HEMI_ARRAY_H__
+#define __HEMI_ARRAY_H__
+
 #include "hemi/hemi.h"
 #include <cstring>
 
@@ -266,3 +269,6 @@ namespace hemi {
         
     };
 } 
+
+#endif // __HEMI_ARRAY_H__
+


### PR DESCRIPTION
Add header guards (`#ifndef`/`#define`) to `hemi/array.h` to prevent double-inclusion.
