### PR TITLE
Assert before deallocating a foreign pointer

### DIFF
--- a/hemi/array.h
+++ b/hemi/array.h
@@ -231,6 +231,7 @@ namespace hemi {
 
         void deallocateHost()
         {
+            assert(!isForeignHostPtr);
             if (isHostAlloced) {
 #ifndef HEMI_CUDA_DISABLE
                 if (isPinned)


### PR DESCRIPTION
You will find a new assert in  ```deallocateHost```. 
I noticed that when calling ```copyFromHost``` or ```copyFromDevice``` with ```nSize != n``` foreign pointers might get accidentally deallocated.

This is not an ideal solution but at least it will expose the issue until a better solution is available.