### PR TITLE
Add support for multi-dimensional parallel_for

### DIFF
--- a/examples/parallel_for/parallel_for.cpp
+++ b/examples/parallel_for/parallel_for.cpp
@@ -9,6 +9,10 @@ int main(void)
 		printf("%d\n", i); 
 	});
 
+	parallel_for(index2d{0, 0}, index2d{10, 10}, [] HEMI_LAMBDA (int i, int j) {
+		printf("%d, %d\n", i, j);
+	});
+
 	deviceSynchronize();
 
 	return 0;

--- a/hemi/device_api.h
+++ b/hemi/device_api.h
@@ -21,20 +21,35 @@
 
 namespace hemi
 {
+    template <unsigned Dim = 0>
 	HEMI_DEV_CALLABLE_INLINE
     unsigned int globalThreadIndex() {
     #ifdef HEMI_DEV_CODE
+        if (Dim == 0)
     	return threadIdx.x + blockIdx.x * blockDim.x;
+        else if (Dim == 1)
+            return threadIdx.y + blockIdx.y * blockDim.y;
+        else if (Dim == 2)
+            return threadIdx.z + blockIdx.z * blockDim.z;
+        else
+            return 0;
     #else
     	return 0;
     #endif
     }
 
-
+    template <unsigned Dim = 0>
     HEMI_DEV_CALLABLE_INLINE
     unsigned int globalThreadCount() {
     #ifdef HEMI_DEV_CODE
+        if (Dim == 0)
     	return blockDim.x * gridDim.x;
+        else if (Dim == 1)
+    	    return blockDim.y * gridDim.y;
+        else if (Dim == 2)
+    	    return blockDim.z * gridDim.z;
+        else
+            return 0;
     #else
     	return 1;
     #endif

--- a/hemi/execution_policy.h
+++ b/hemi/execution_policy.h
@@ -14,7 +14,28 @@
 ///////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#ifndef HEMI_CUDA_DISABLE
+#include <cuda_runtime_api.h>
+#else
+struct dim3 {
+    unsigned x;
+    unsigned y;
+    unsigned z;
+
+    dim3(unsigned x = 0, unsigned y = 0, unsigned z = 0) :
+        x{x},
+        y{y},
+        z{z}
+    {}
+};
+#endif
+
 #include "hemi/hemi.h"
+
+bool equals(dim3 a, dim3 b)
+{
+    return a.x == b.x && a.y == b.y && a.z == b.z;
+}
 
 namespace hemi {
 
@@ -28,24 +49,27 @@ public:
         FullManual = GridSize | BlockSize | SharedMem
     };
 
-    ExecutionPolicy() 
-    : mState(Automatic), 
-      mGridSize(0), 
-      mBlockSize(0), 
+    ExecutionPolicy(unsigned dimensions)
+    : mDimensions(dimensions),
+      mState(Automatic),
+      mGrid(0, 0, 0),
+      mBlock(0, 0, 0),
       mSharedMemBytes(0),
       mStream((hemiStream_t)0) {}
     
-    ExecutionPolicy(int gridSize, int blockSize, size_t sharedMemBytes)
-    : mState(0), mStream(0) {
-      setGridSize(gridSize);
-      setBlockSize(blockSize);
+    ExecutionPolicy(dim3 grid, dim3 block, size_t sharedMemBytes)
+    : mDimensions(computeDimensions(grid, block)),
+      mState(0), mStream(0) {
+      setGrid(grid);
+      setBlock(block);
       setSharedMemBytes(sharedMemBytes);  
     }
 
-    ExecutionPolicy(int gridSize, int blockSize, size_t sharedMemBytes, hemiStream_t stream)
-    : mState(0) {
-      setGridSize(gridSize);
-      setBlockSize(blockSize);
+    ExecutionPolicy(dim3 grid, dim3 block, size_t sharedMemBytes, hemiStream_t stream)
+    : mDimensions(computeDimensions(grid, block)),
+      mState(0) {
+      setGrid(grid),
+      setBlock(block),
       setSharedMemBytes(sharedMemBytes);
       setStream(stream);
     }
@@ -54,19 +78,29 @@ public:
 
     int    getConfigState()    const { return mState;          }
     
-    int    getGridSize()       const { return mGridSize;       }
-    int    getBlockSize()      const { return mBlockSize;      }
+    dim3   getDimensions()     const { return mDimensions;     }
+    dim3   getGrid()           const { return mGrid;           }
+    dim3   getBlock()          const { return mBlock;          }
+    int    getGridSize()       const { return mGrid.x * mGrid.y * mGrid.z;    }
+    int    getBlockSize()      const { return mBlock.x * mBlock.y * mBlock.z; }
     int    getMaxBlockSize()   const { return mMaxBlockSize;   }
     size_t getSharedMemBytes() const { return mSharedMemBytes; }
     hemiStream_t getStream()   const { return mStream; }
  
     void setGridSize(int arg) { 
-        mGridSize = arg;  
-        if (mGridSize > 0) mState |= GridSize; 
+        setGrid(dim3(arg, 1, 1));
+    }
+    void setBlockSize(int arg) {
+        setBlock(dim3(arg, 1, 1));
+    }
+    void setGrid(dim3 arg) {
+        mGrid = arg;
+        if (!equals(mGrid, dim3(0, 0, 0))) mState |= GridSize;
         else mState &= (FullManual - GridSize);
     }   
-    void setBlockSize(int arg) { mBlockSize = arg; 
-        if (mBlockSize > 0) mState |= BlockSize; 
+    void setBlock(dim3 arg) {
+        mBlock = arg;
+        if (!equals(mBlock, dim3(0, 0, 0))) mState |= BlockSize;
         else mState &= (FullManual - BlockSize);
     }
     void setMaxBlockSize(int arg) {
@@ -81,9 +115,21 @@ public:
     }
 
 private:
+    static unsigned computeDimensions(dim3 gridSize, dim3 blockSize)
+    {
+        if (gridSize.z > 1 || blockSize.z > 1)
+            return 3;
+        if (gridSize.y > 1 || blockSize.y > 1)
+            return 2;
+        if (gridSize.x > 1 || blockSize.x > 1)
+            return 1;
+        return 0;
+    }
+
+    unsigned mDimensions;
     int    mState;
-    int    mGridSize;
-    int    mBlockSize;
+    dim3   mGrid;
+    dim3   mBlock;
     int    mMaxBlockSize;
     size_t mSharedMemBytes;
     hemiStream_t mStream;

--- a/hemi/grid_stride_range.h
+++ b/hemi/grid_stride_range.h
@@ -28,11 +28,11 @@ using step_range = typename range_proxy<T>::step_range_proxy;
 
 namespace hemi {
 
-	template <typename T>
+	template <unsigned Dim, typename T>
 	HEMI_DEV_CALLABLE_INLINE
 	step_range<T> grid_stride_range(T begin, T end) {
-	    begin += hemi::globalThreadIndex();
-	    return range(begin, end).step(hemi::globalThreadCount());
+	    begin += hemi::globalThreadIndex<Dim>();
+	    return range(begin, end).step(hemi::globalThreadCount<Dim>());
 	}
 	
 }

--- a/hemi/launch.inl
+++ b/hemi/launch.inl
@@ -28,7 +28,7 @@ template <typename Function, typename... Arguments>
 void launch(Function f, Arguments... args)
 {
 #ifdef HEMI_CUDA_COMPILER
-    ExecutionPolicy p;
+    ExecutionPolicy p(1);
     launch(p, f, args...);
 #else
     Kernel(f, args...);
@@ -64,7 +64,7 @@ template <typename... Arguments>
 void cudaLaunch(void(*f)(Arguments... args), Arguments... args)
 {
 #ifdef HEMI_CUDA_COMPILER
-    ExecutionPolicy p;
+    ExecutionPolicy p(1);
     cudaLaunch(p, f, args...);
 #else
     f(args...);

--- a/hemi/parallel_for.h
+++ b/hemi/parallel_for.h
@@ -25,18 +25,106 @@
 
 namespace hemi 
 {
+	template <unsigned Dims, typename T = int>
+	struct index {
+		T values[Dims];
+
+		index(std::initializer_list<T> values_)
+		{
+			std::copy(values_.begin(), values_.end(), std::begin(values));
+		}
+
+		bool operator==(index const& other) const
+		{
+		    return std::equal(std::begin(values), std::end(values), std::begin(other.values));
+		}
+
+		bool operator!=(index const& other) const
+		{
+		    return !(*this == other);
+		}
+	};
+
+	template <typename T>
+	constexpr unsigned get_index_dims(const T &idx)
+	{
+		return 1;
+	}
+
+	template <unsigned Dims, typename T>
+	constexpr unsigned get_index_dims(const index<Dims, T> &idx)
+	{
+		return Dims;
+	}
+
 	class ExecutionPolicy; // forward decl
 
+	using index1d = index<1>;
+	using index2d = index<2>;
+	using index3d = index<3>;
+
 	template <typename index_type, typename F>
-	void parallel_for(index_type first, index_type last, F function) {
-		ExecutionPolicy p;
+	void parallel_for(const index_type &first, const index_type &last, F function) {
+		ExecutionPolicy p(get_index_dims(first));
 		parallel_for(p, first, last, function);
 	}
 
 	template <typename index_type, typename F>
 	void parallel_for(const ExecutionPolicy &p, index_type first, index_type last, F function) {
 		hemi::launch(p, [=] HEMI_LAMBDA () {
-			for (auto idx : grid_stride_range(first, last)) function(idx);
+			for (auto idx : grid_stride_range<0>(first, last)) function(idx);
 		});
 	}
+
+	template <typename index_type, typename F>
+	void parallel_for(const ExecutionPolicy &p,
+					  const index<3, index_type> &first,
+					  const index<3, index_type> &last,
+					  F function) {
+		hemi::launch(p, [=] HEMI_LAMBDA () {
+#ifdef HEMI_DEBUG
+			printf("{%d, %d, %d} -> {%d, %d, %d}\n", first.values[2], first.values[1], first.values[0], last.values[2], last.values[1], last.values[0]);
+#endif
+			for (auto idx_i : grid_stride_range<2>(first.values[2], last.values[2])) {
+				for (auto idx_j : grid_stride_range<1>(first.values[1], last.values[1])) {
+					for (auto idx_k : grid_stride_range<0>(first.values[0], last.values[0])) {
+						function(idx_i, idx_j, idx_k);
+					}
+				}
+			}
+		});
+	}
+
+    template <typename index_type, typename F>
+	void parallel_for(const ExecutionPolicy &p,
+					  const index<2, index_type> &first,
+					  const index<2, index_type> &last,
+					  F function) {
+		hemi::launch(p, [=] HEMI_LAMBDA () {
+#ifdef HEMI_DEBUG
+			printf("{%d, %d} -> {%d, %d}\n", first.values[1], first.values[0], last.values[1], last.values[0]);
+#endif
+			for (auto idx_i : grid_stride_range<1>(first.values[1], last.values[1])) {
+				for (auto idx_j : grid_stride_range<0>(first.values[0], last.values[0])) {
+					function(idx_i, idx_j);
+				}
+			}
+		});
+	}
+
+    template <typename index_type, typename F>
+	void parallel_for(const ExecutionPolicy &p,
+					  const index<1, index_type> &first,
+					  const index<1, index_type> &last,
+					  F function) {
+		hemi::launch(p, [=] HEMI_LAMBDA () {
+#ifdef HEMI_DEBUG
+			printf("{%d} -> {%d}\n", first.values[0], last.values[0]);
+#endif
+			for (auto idx_i : grid_stride_range<0>(first.values[0], last.values[0])) {
+				function(idx_i);
+			}
+		});
+	}
+
 }


### PR DESCRIPTION
I have implemented support for multi-dimensional (up to 3 dimensions) parallel_for. I have added an optional multidimensional index type for programmers to use in parallel_for invocations (plain integer values can be still used for 1D parallel_for). Grid and block in execution policy are dim3 values, now. However, in this first implementation blocks and grids are flattened to 1D. The rest of the dimensions in the iteration space are iterated within each thread. More intelligent policies can be implemented later. Check the modified example in parallel_for.

Please, let me know if you find this feature interesting or if I need to change anything to have it integrated.