### PR TITLE
Avoid calling cudaGetDeviceProperties() every single time a kernel is invoked

### DIFF
--- a/hemi/array.h
+++ b/hemi/array.h
@@ -131,6 +131,7 @@ namespace hemi {
             if (isDeviceValid && !isHostValid) copyDeviceToHost();
             else assert(isHostValid);
             isDeviceValid = false;
+            isHostValid   = true;
             return hPtr;
         }
 
@@ -138,6 +139,7 @@ namespace hemi {
         {
             if (!isDeviceValid && isHostValid) copyHostToDevice();
             else assert(isDeviceValid);
+            isDeviceValid = true;
             isHostValid = false;
             return dPtr;
         }


### PR DESCRIPTION
Avoid calling cudaGetDeviceProperties() every single time a kernel is invoked. It badly hurts performance and it makes the video card whistle ominously (tested on GeForce GTX 970/Linux).