### PR TITLE
Streams support, block_stride_range, extras

### DIFF
--- a/hemi/array.h
+++ b/hemi/array.h
@@ -82,7 +82,7 @@ namespace hemi {
         void setAsync(bool async, stream_t stream = 0)
         {
             isAsync = async;
-            this->streamID = streamID;
+            streamID = stream;
         }
 
         // Make all memory transfers asynchronous and use the target stream.
@@ -91,7 +91,7 @@ namespace hemi {
         void setAsync(bool async, Stream & stream)
         {
             isAsync = async;
-            this->streamID = stream.id();
+            streamID = stream.id();
         }
 
 

--- a/hemi/array.h
+++ b/hemi/array.h
@@ -74,7 +74,8 @@ namespace hemi {
         }
 
         size_t size() const { return nSize; }
-
+        bool async() const { return isAsync; }
+        stream_t stream() const { return streamID; }
 
         // Make all memory transfers asynchronous.
         // The user must take care himself not to access the host memory until
@@ -93,11 +94,6 @@ namespace hemi {
             isAsync = async;
             streamID = stream.id();
         }
-
-
-        bool async() const { return isAsync; }
-        stream_t stream() const { return streamID; }
-
 
         // copy from/to raw external pointers (host or device)
 

--- a/hemi/array.h
+++ b/hemi/array.h
@@ -131,7 +131,6 @@ namespace hemi {
             if (isDeviceValid && !isHostValid) copyDeviceToHost();
             else assert(isHostValid);
             isDeviceValid = false;
-            isHostValid   = true;
             return hPtr;
         }
 
@@ -139,7 +138,6 @@ namespace hemi {
         {
             if (!isDeviceValid && isHostValid) copyHostToDevice();
             else assert(isDeviceValid);
-            isDeviceValid = true;
             isHostValid = false;
             return dPtr;
         }

--- a/hemi/execution_policy.h
+++ b/hemi/execution_policy.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "hemi/hemi.h"
+#include "hemi/stream.h"
 
 namespace hemi {
 
@@ -33,7 +34,7 @@ public:
       mGridSize(0), 
       mBlockSize(0), 
       mSharedMemBytes(0),
-      mStream((hemiStream_t)0) {}
+      mStream(0) {}
     
     ExecutionPolicy(int gridSize, int blockSize, size_t sharedMemBytes)
     : mState(0), mStream(0) {
@@ -42,7 +43,15 @@ public:
       setSharedMemBytes(sharedMemBytes);  
     }
 
-    ExecutionPolicy(int gridSize, int blockSize, size_t sharedMemBytes, hemiStream_t stream)
+    ExecutionPolicy(int gridSize, int blockSize, size_t sharedMemBytes, Stream & stream)
+    : mState(0) {
+      setGridSize(gridSize);
+      setBlockSize(blockSize);
+      setSharedMemBytes(sharedMemBytes);
+      setStream(stream);
+    }
+
+    ExecutionPolicy(int gridSize, int blockSize, size_t sharedMemBytes, stream_t stream)
     : mState(0) {
       setGridSize(gridSize);
       setBlockSize(blockSize);
@@ -52,13 +61,12 @@ public:
           
     ~ExecutionPolicy() {}
 
-    int    getConfigState()    const { return mState;          }
-    
-    int    getGridSize()       const { return mGridSize;       }
-    int    getBlockSize()      const { return mBlockSize;      }
-    int    getMaxBlockSize()   const { return mMaxBlockSize;   }
-    size_t getSharedMemBytes() const { return mSharedMemBytes; }
-    hemiStream_t getStream()   const { return mStream; }
+    int      getConfigState()    const { return mState;          }
+    int      getGridSize()       const { return mGridSize;       }
+    int      getBlockSize()      const { return mBlockSize;      }
+    int      getMaxBlockSize()   const { return mMaxBlockSize;   }
+    size_t   getSharedMemBytes() const { return mSharedMemBytes; }
+    stream_t getStream()         const { return mStream;         }
  
     void setGridSize(int arg) { 
         mGridSize = arg;  
@@ -76,7 +84,10 @@ public:
         mSharedMemBytes = arg; 
         mState |= SharedMem; 
     }
-    void setStream(hemiStream_t stream) {
+    void setStream(Stream & stream) {
+        mStream = stream.id();
+    }
+    void setStream(stream_t stream) {
         mStream = stream;
     }
 
@@ -86,7 +97,7 @@ private:
     int    mBlockSize;
     int    mMaxBlockSize;
     size_t mSharedMemBytes;
-    hemiStream_t mStream;
+    stream_t mStream;
 };
 
 }

--- a/hemi/grid_stride_range.h
+++ b/hemi/grid_stride_range.h
@@ -23,17 +23,21 @@
 using namespace util::lang;
 
 // type alias to simplify typing...
-template<typename T>
-using step_range = typename range_proxy<T>::step_range_proxy;
+using step_range = typename range_proxy<int>::step_range_proxy;
 
 namespace hemi {
 
-	template <typename T>
 	HEMI_DEV_CALLABLE_INLINE
-	step_range<T> grid_stride_range(T begin, T end) {
+	step_range grid_stride_range(int begin, int end) {
 	    begin += hemi::globalThreadIndex();
 	    return range(begin, end).step(hemi::globalThreadCount());
 	}
+
+	HEMI_DEV_CALLABLE_INLINE
+	step_range block_stride_range(int begin, int end) {
+	    begin += hemi::localThreadIndex();
+	    return range(begin, end).step(hemi::localThreadCount());
+	}	
 	
 }
 /////////////////////////////////////////////////////////////////

--- a/hemi/hemi.h
+++ b/hemi/hemi.h
@@ -60,6 +60,7 @@
   // Memory specifiers
   #define HEMI_MEM_DEVICE                 __device__
   #define HEMI_MEM_SHARED                 __shared__
+  #define HEMI_MEM_MANAGED                __managed__
 
   // Constants: declares both a device and a host copy of this constant
   // static and extern flavors can be used to declare static and extern
@@ -107,6 +108,7 @@
   // memory specifiers
   #define HEMI_MEM_DEVICE
   #define HEMI_MEM_SHARED  
+  #define HEMI_MEM_MANAGED
 
   #define HEMI_DEFINE_CONSTANT(def, value) def ## _hostconst = value
   #define HEMI_DEFINE_STATIC_CONSTANT(def, value) static def ## _hostconst = value

--- a/hemi/hemi.h
+++ b/hemi/hemi.h
@@ -60,9 +60,6 @@
   // Memory specifiers
   #define HEMI_MEM_DEVICE                 __device__
 
-  // Stream type
-  typedef cudaStream_t hemiStream_t;
-
   // Constants: declares both a device and a host copy of this constant
   // static and extern flavors can be used to declare static and extern
   // linkage as required.
@@ -109,9 +106,6 @@
   // memory specifiers
   #define HEMI_MEM_DEVICE
 
-  // Stream type
-  typedef int hemiStream_t;
-
   #define HEMI_DEFINE_CONSTANT(def, value) def ## _hostconst = value
   #define HEMI_DEFINE_STATIC_CONSTANT(def, value) static def ## _hostconst = value
   #define HEMI_DEFINE_EXTERN_CONSTANT(def) extern def ## _hostconst
@@ -145,13 +139,11 @@
 
 namespace hemi {
 
-    inline hemi::Error_t deviceSynchronize() 
+    inline void deviceSynchronize()
     {
-#ifdef HEMI_CUDA_COMPILER
-        if (cudaSuccess != checkCuda(cudaDeviceSynchronize()))
-            return hemi::cudaError; 
+#ifndef HEMI_CUDA_DISABLE
+        checkCuda( cudaDeviceSynchronize() );
 #endif
-        return hemi::success;
     }
-
+    
 } // namespace hemi

--- a/hemi/hemi.h
+++ b/hemi/hemi.h
@@ -59,6 +59,7 @@
 
   // Memory specifiers
   #define HEMI_MEM_DEVICE                 __device__
+  #define HEMI_MEM_SHARED                 __shared__
 
   // Constants: declares both a device and a host copy of this constant
   // static and extern flavors can be used to declare static and extern
@@ -105,6 +106,7 @@
 
   // memory specifiers
   #define HEMI_MEM_DEVICE
+  #define HEMI_MEM_SHARED  
 
   #define HEMI_DEFINE_CONSTANT(def, value) def ## _hostconst = value
   #define HEMI_DEFINE_STATIC_CONSTANT(def, value) static def ## _hostconst = value

--- a/hemi/managed.h
+++ b/hemi/managed.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "hemi/hemi.h"
+#include <cstdlib>
+#include <cassert>
+
+namespace hemi {
+
+template <typename T>
+T * mallocManaged(size_t len)
+{
+    T * ptr;
+#ifndef HEMI_CUDA_DISABLE
+    checkCuda( cudaMallocManaged(&ptr, len * sizeof(T), cudaMemAttachGlobal) );
+#else
+    ptr = (T *) std::malloc(len * sizeof(T));
+#endif
+    // It has been reported that after 65536 small allocations, cudaMallocManaged returns
+    // cudaSuccess and sets the pointer to NULL
+    assert(ptr != nullptr);
+    return ptr;
+}
+
+
+void freeManaged(void * ptr)
+{
+#ifndef HEMI_CUDA_DISABLE
+    checkCuda( cudaFree(ptr) );
+#else
+    std::free(ptr);
+#endif    
+}
+
+
+// Allocator to use with any member of the Standard Library.
+// e.g. std::vector<float, hemi::ManagedAllocator<float>>
+// Note however that while the data in the vector in the above example will be accessible
+// from device space, everything else (e.g. std::vector::size()) won't be usable.
+// You must extract the pointer to the first element and length while in host code.
+template<class T>
+class ManagedAllocator
+{
+public:
+    using value_type = T;
+
+    value_type * allocate(size_t n)
+    {
+        return mallocManaged<T>(n);
+    }
+  
+    void deallocate(value_type * ptr, size_t)
+    {
+        freeManaged(ptr);
+    }
+};
+
+}

--- a/hemi/parallel_for.h
+++ b/hemi/parallel_for.h
@@ -27,27 +27,14 @@ namespace hemi
 {
 	class ExecutionPolicy; // forward decl
 
-	template <typename index_type, typename F>
-	void parallel_for(index_type first, index_type last, F function) {
-		ExecutionPolicy p;
-		parallel_for(p, first, last, function);
-	}
-
-	template <typename index_type, typename F>
-	void parallel_for(const ExecutionPolicy &p, index_type first, index_type last, F function) {
-		hemi::launch(p, [=] HEMI_LAMBDA () {
-			for (auto idx : grid_stride_range(first, last)) function(idx);
-		});
-	}
-
 	template <typename F>
-	void parallel_for(size_t first, size_t last, F function) {
+	void parallel_for(int first, int last, F function) {
 		ExecutionPolicy p;
 		parallel_for(p, first, last, function);
 	}
 
 	template <typename F>
-	void parallel_for(const ExecutionPolicy &p, size_t first, size_t last, F function) {
+	void parallel_for(const ExecutionPolicy &p, int first, int last, F function) {
 		hemi::launch(p, [=] HEMI_LAMBDA () {
 			for (auto idx : grid_stride_range(first, last)) function(idx);
 		});

--- a/hemi/stream.h
+++ b/hemi/stream.h
@@ -1,0 +1,76 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// "Hemi" CUDA Portable C/C++ Utilities
+//
+// Copyright 2012-2015 NVIDIA Corporation
+//
+// License: BSD License, see LICENSE file in Hemi home directory
+//
+// The home for Hemi is https://github.com/harrism/hemi
+//
+///////////////////////////////////////////////////////////////////////////////
+// Please see the file README.md (https://github.com/harrism/hemi/README.md)
+// for full documentation and discussion.
+///////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "hemi/hemi.h"
+
+namespace hemi {
+
+#ifndef HEMI_CUDA_DISABLE
+    typedef cudaStream_t stream_t;
+
+    class Stream
+    {
+    public:
+        Stream()
+        {
+            checkCuda( cudaStreamCreate(&stream) );
+        }
+
+        ~Stream()
+        {
+            checkCuda( cudaStreamDestroy(stream) );
+        }
+
+        void synchronize() const
+        {
+            checkCuda( cudaStreamSynchronize(stream) );
+        }
+
+        // return true if all operations in the stream have completed; false otherwise
+        bool query() const
+        {
+            auto res = cudaStreamQuery(stream);
+            switch(res) {
+                case cudaSuccess: return true;
+                case cudaErrorNotReady: return false;
+                default: checkCuda(res); return false;
+            }
+        }
+
+        stream_t id() const
+        {
+            return stream;
+        }
+
+    private:
+        stream_t stream;
+    };
+
+#else
+    typedef int stream_t;
+
+    class Stream
+    {
+    public:
+        void synchronize() const {};
+        bool query() const {return true};
+        stream_t id() const {return 0};
+    };
+
+    typedef Stream NullStream;
+#endif
+
+} //namespace

--- a/hemi/stream.h
+++ b/hemi/stream.h
@@ -15,39 +15,216 @@
 #pragma once
 
 #include "hemi/hemi.h"
+#include <utility>
 
 namespace hemi {
 
 #ifndef HEMI_CUDA_DISABLE
     typedef cudaStream_t stream_t;
+    typedef cudaEvent_t event_t;
+#else
+    
+    typedef int stream_t;
+    typedef int event_t;
+#endif
 
-    class Stream
+    // forward declaration
+    class Stream;
+
+    class Event
     {
     public:
-        Stream()
+        // blockingSync: Specifies that event should use blocking synchronization.
+        // A host thread that uses synchronize() to wait on an event created with
+        // this flag will block until the event actually completes.
+        // disableTiming: Specifies that the created event does not need to record
+        // timing data. Events created with this flag specified and the blockingSync
+        // flag not specified will provide the best performance when used with
+        // hemi::Stream::waitEvent() and hemi::Event::query().
+        Event(bool blockingSync = false, bool disableTiming = false):
+            event(0),
+            isForeign(false)
         {
-            checkCuda( cudaStreamCreate(&stream) );
+#ifndef HEMI_CUDA_DISABLE
+            auto flags = cudaEventDefault;
+            if (blockingSync) flags |= cudaEventBlockingSync;
+            if (disableTiming) flags |= cudaEventDisableTiming;
+            checkCuda( cudaEventCreateWithFlags(&event, flags) );
+#endif
         }
 
-        ~Stream()
+        Event(event_t id):
+            event(id),
+            isForeign(true)
+        {}
+
+        Event(Event & rhs):
+            event(rhs.id()),
+            isForeign(true)
+        {}
+
+        ~Event()
         {
-            checkCuda( cudaStreamDestroy(stream) );
+#ifndef HEMI_CUDA_DISABLE        
+            if (!isForeign) checkCuda( cudaEventDestroy(event) );
+#endif
         }
 
+        // Block host code until event is completed
+        // Return immediately if record() was never called
         void synchronize() const
         {
-            checkCuda( cudaStreamSynchronize(stream) );
+#ifndef HEMI_CUDA_DISABLE        
+            checkCuda( cudaEventSynchronize(event) );
+#endif
+        }
+        
+        // Any future work submitted in any stream will wait for this event to complete before
+        // beginning execution. This effectively creates a barrier for all future work submitted
+        // to the device on this thread.
+        void syncStreams() const
+        {
+#ifndef HEMI_CUDA_DISABLE        
+            checkCuda( cudaStreamWaitEvent(NULL, event, 0) );
+#endif
         }
 
         // return true if all operations in the stream have completed; false otherwise
         bool query() const
         {
+#ifndef HEMI_CUDA_DISABLE
+            auto res = cudaEventQuery(event);
+            switch(res) {
+                case cudaSuccess: return true;
+                case cudaErrorNotReady: return false;
+                default: checkCuda(res); return false;
+            }
+#else
+            return true;
+#endif                        
+        }
+
+        void record(stream_t stream = 0) const
+        {
+#ifndef HEMI_CUDA_DISABLE        
+            checkCuda( cudaEventRecord(event, stream) );
+#endif            
+        }
+
+        void record(Stream & stream) const;
+        // Implementation must happen after the definition of Stream
+        //{
+        //    record(stream.id());
+        //}
+
+        // if both Events have completed, returns <true, (this - other)>
+        // if one of the Events has not completed yet, returns <false, 0>
+        std::pair<bool, float> elapsedTime(event_t other) const
+        {
+            float ms = 0.0;
+            bool isCompleted;
+
+#ifndef HEMI_CUDA_DISABLE
+            auto res = cudaEventElapsedTime(&ms, other, event);
+            switch(res) {
+                case cudaSuccess:
+                    isCompleted = true;
+                    break;
+                case cudaErrorInvalidResourceHandle:
+                    // record() has not been called on either stream,
+                    // or either event was created with disableTiming
+                    isCompleted = true;
+                    break;
+                case cudaErrorNotReady:
+                    isCompleted = false;
+                    break;
+                default:
+                    checkCuda(res);
+            }
+#else
+            isCompleted = true;
+#endif
+            return std::make_pair(isCompleted, ms);
+        }
+
+        std::pair<bool, float> elapsedTime(Event & other) const
+        {
+            return elapsedTime(other.id());   
+        }
+
+        event_t id() const
+        {
+            return event;
+        }
+
+    private:
+        event_t event;
+        bool isForeign;
+    };
+
+
+    class Stream
+    {
+    public:
+        Stream():
+            isForeign(false)
+        {
+#ifndef HEMI_CUDA_DISABLE        
+            checkCuda( cudaStreamCreate(&stream) );
+#else
+            stream = 0;
+#endif
+        }
+        
+        Stream(stream_t id):
+            stream(id),
+            isForeign(true)
+        {}
+        
+        Stream(Stream & rhs):
+            stream(rhs.id()),
+            isForeign(true)
+        {}        
+
+        ~Stream()
+        {
+#ifndef HEMI_CUDA_DISABLE        
+            if (!isForeign) checkCuda( cudaStreamDestroy(stream) );
+#endif
+        }
+
+        void synchronize() const
+        {
+#ifndef HEMI_CUDA_DISABLE        
+            checkCuda( cudaStreamSynchronize(stream) );
+#endif            
+        }
+
+        // return true if all operations in the stream have completed; false otherwise
+        bool query() const
+        {
+#ifndef HEMI_CUDA_DISABLE        
             auto res = cudaStreamQuery(stream);
             switch(res) {
                 case cudaSuccess: return true;
                 case cudaErrorNotReady: return false;
                 default: checkCuda(res); return false;
             }
+#else
+            return true;
+#endif            
+        }
+
+        void waitEvent(event_t event) const
+        {
+#ifndef HEMI_CUDA_DISABLE
+            checkCuda( cudaStreamWaitEvent(stream, event, 0) );
+#endif            
+        }
+
+        void waitEvent(Event & event) const
+        {
+            waitEvent(event.id());
         }
 
         stream_t id() const
@@ -57,20 +234,13 @@ namespace hemi {
 
     private:
         stream_t stream;
+        bool isForeign;
     };
 
-#else
-    typedef int stream_t;
 
-    class Stream
+    void Event::record(Stream & stream) const
     {
-    public:
-        void synchronize() const {};
-        bool query() const {return true};
-        stream_t id() const {return 0};
-    };
-
-    typedef Stream NullStream;
-#endif
+        record(stream.id());
+    }
 
 } //namespace


### PR DESCRIPTION
WARNING: all changes are lightly tested and are missing the unit tests.

Added object-oriented streams support. Analogously to hemi::Array, it cleans up the device resources when it falls out of scope. Added support for asynchronous copies to hemi::Array.

Added HEMI_SHARED memory decorator. Even if __shared__ memory will make CPU code slower (as it's just an extra memory copy), this change allows to run the CUDA branch of an algorithm in CPU space, which is great for debugging/testing purposes and whenever the developer can't be bothered writing an optimized CPU variant of his code (a very likely use case).

Removed templates from parallel_for and grid_stride_range. Feel free to discard if you think that supporting custom overloaded index-like classes (unlikely IMHO) is better than having cleaner code.
Changed size_t to int in parallel_for, as one may legitimately want to iterate on negative indexes (e.g. when accessing memory that starts at an offset).
New function block_stride_range that is very useful e.g. to initialise __shared__ memory without needing to bother to set the number of threads per block.

Private variable cleanups in hemi::Array.
