### PR TITLE
portable interpolated look-up table using texture memory

### DIFF
--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -19,8 +19,8 @@ CXX_FLAGS  := $(STD) -I../../
 HOST_ONLY_FLAGS := -DHEMI_CUDA_DISABLE
 
 # uncomment for debug
-DEBUG_FLAGS := -g -DDEBUG
-DEBUG_FLAGS_NVCC := -G
+#DEBUG_FLAGS := -g -DDEBUG
+#DEBUG_FLAGS_NVCC := -G
 
 # comment for debug
 CXX_FLAGS += -O3

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -67,6 +67,9 @@ saxpy_device: saxpy.cpp
 lookup_table_host: lookup_table.cpp
 	$(CXX) $? $(CXX_FLAGS) $(HOST_ONLY_FLAGS) -o $@
 
+lookup_table_device: lookup_table.cpp
+	$(NVCC) $? $(NVCC_FLAGS) -x cu -o $@
+
 clean:
 	rm -f $(EXES) *.o
 	rm -rf *.dSYM

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -33,7 +33,7 @@ EXES := hello_device hello_host_nvcc hello_host \
 		hello_lambda_device hello_lambda_host_nvcc hello_lambda_host \
         hello_global \
         saxpy_host saxpy_device \
-	lookup_table_host
+	lookup_table_host lookup_table_device lookup_table_validate \
 
 all: $(EXES)
 
@@ -64,10 +64,13 @@ saxpy_host: saxpy.cpp
 saxpy_device: saxpy.cpp
 	$(NVCC) $? $(NVCC_FLAGS) -x cu -o $@
 
-lookup_table_host: lookup_table.cpp
+lookup_table_host: hello_lookup.cpp
 	$(CXX) $? $(CXX_FLAGS) $(HOST_ONLY_FLAGS) -o $@
 
-lookup_table_device: lookup_table.cpp
+lookup_table_device: hello_lookup.cpp
+	$(NVCC) $? $(NVCC_FLAGS) -x cu -o $@
+
+lookup_table_validate: lookup_table_validate.cpp
 	$(NVCC) $? $(NVCC_FLAGS) -x cu -o $@
 
 clean:

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -19,8 +19,8 @@ CXX_FLAGS  := $(STD) -I../../
 HOST_ONLY_FLAGS := -DHEMI_CUDA_DISABLE
 
 # uncomment for debug
-#DEBUG_FLAGS := -g -DDEBUG
-#DEBUG_FLAGS_NVCC := -G
+DEBUG_FLAGS := -g -DDEBUG
+DEBUG_FLAGS_NVCC := -G
 
 # comment for debug
 CXX_FLAGS += -O3
@@ -32,7 +32,8 @@ NVCC_FLAGS := $(CXX_FLAGS) $(DEBUG_FLAGS_NVCC) --expt-extended-lambda
 EXES := hello_device hello_host_nvcc hello_host \
 		hello_lambda_device hello_lambda_host_nvcc hello_lambda_host \
         hello_global \
-        saxpy_host saxpy_device
+        saxpy_host saxpy_device \
+	lookup_table_host
 
 all: $(EXES)
 

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -63,6 +63,9 @@ saxpy_host: saxpy.cpp
 saxpy_device: saxpy.cpp
 	$(NVCC) $? $(NVCC_FLAGS) -x cu -o $@
 
+lookup_table_host: lookup_table.cpp
+	$(CXX) $? $(CXX_FLAGS) $(HOST_ONLY_FLAGS) -o $@
+
 clean:
 	rm -f $(EXES) *.o
 	rm -rf *.dSYM

--- a/examples/simple/hello_lookup.cpp
+++ b/examples/simple/hello_lookup.cpp
@@ -1,0 +1,59 @@
+#include <stdio.h>
+
+#include "hemi/hemi.h"
+#include "hemi/array.h"
+#include "hemi/table.h"
+#include "hemi/parallel_for.h"
+
+void lookup(const int n, float *val, const hemi::table3<float> *lookupTable, const float x, const float y, const float z)
+{
+  hemi::parallel_for(0, n, [=] HEMI_LAMBDA (int i) {
+      val[i] = lookupTable->lookup(x, y, z);
+    });
+}
+
+int main(void) 
+{
+  // init random generator
+  std::srand(0);
+
+  // number of lookups to perform
+  const int n = 1;
+
+  // lookup table dimensions
+  const int nx = 32, ny = 32, nz = 32;
+
+  hemi::Array<float> output(n);
+  hemi::Table3D<float> lookup_table(nx, ny, nz,     // dimensions
+				    0.0, 0.0, 0.0,  // lower edge
+				    1.0, 1.0, 1.0); // upper edge
+  
+  // fill the table with random numbers between 0 and 1
+  for (int z = 0; z < nz; ++z)
+    for (int y = 0; y < ny; ++y)
+      for (int x = 0; x < nx; ++x)
+        {
+	  // host pointer is 1D, but we are storing 3D data there, so use hemi::index to flatten the array indices
+	  lookup_table.writeOnlyHostPtr()[hemi::index(x, y, z, nx, ny)] = std::rand() / (float)RAND_MAX;
+	}
+
+#ifndef HEMI_CUDA_DISABLE
+  // if compiled with CUDA, run on device        
+  float *output_array = output.devicePtr();
+  const hemi::table3<float> *lookup_table_ptr = lookup_table.readOnlyDevicePtr();
+#else
+  // else, lets run on CPU
+  float *output_array = output.hostPtr();
+  const hemi::table3<float> *lookup_table_ptr = lookup_table.readOnlyHostPtr();
+#endif
+  
+  // perform the lookup
+  lookup(n, output_array, lookup_table_ptr, 0.5, 0.5, 0.5);
+  
+  // print out the result
+  for (int i = 0; i < n; ++i) {
+    printf("%f\n", output.hostPtr()[i]);
+  }
+  
+  return 0;
+}

--- a/examples/simple/lookup_table.cpp
+++ b/examples/simple/lookup_table.cpp
@@ -1,12 +1,51 @@
 #include <stdio.h>
 #include "hemi/hemi.h"
+#include "hemi/array.h"
 #include "hemi/table.h"
 #include "hemi/launch.h"
+#include "hemi/parallel_for.h"
 #include "hemi/device_api.h"
+
+void lookup(const int n, float *val, const hemi::table3D<float> lookupTable, const float x, const float y, const float z)
+{
+  hemi::parallel_for(0, n, [&] HEMI_LAMBDA (int i) {
+      val[i] = lookupTable.lookup(1.0, 1.0, 1.0);
+    });
+}
+
+inline int index(int x, int y, int z, int dx, int dy)
+{
+  return x + dx * (y + dy*z);
+}
 
 int main(void) {
 
-  hemi::Table3D<float> lookup_table(5, 5, 5);
+  const int n = 1000;
+  const int nx = 5, ny = 5, nz = 5;
+
+  float *table_array = new float[nx*ny*nz];
+
+  // lets make some test data
+  for (int z = 0; z < nz; ++z)
+    for (int y = 0; y < ny; ++y)
+      for (int x = 0; x < nx; ++x)
+	table_array[hemi::index(x,y,z,nx,ny)] = 0.5f;
+
+  hemi::Array<float> output(n);
+  hemi::Table3D<float> lookup_table(nx, ny, nz, table_array);
   
+  //hemi::table3D<float> honk;
+  //printf("%f", honk.lookup(1,1,1));
+
+  //const hemi::table3D<float> tbl = lookup_table.readOnlyTable();
+  //printf("%f/n", tbl.lookup(1.0, 1.0, 1.0));
+  
+  //printf("%f", lookup_table.readOnlyTable().lookup(1,1,1));
+  
+  lookup(n, output.hostPtr(), lookup_table.readOnlyTable(), 2.5, 2.5, 2.5);
+  printf("element 0 = %f\n", output.hostPtr()[0]);
+
+  //delete [] table_array;
+
   return 0;
 }

--- a/examples/simple/lookup_table.cpp
+++ b/examples/simple/lookup_table.cpp
@@ -1,8 +1,9 @@
 #include <stdio.h>
+
 #include "hemi/hemi.h"
 #include "hemi/array.h"
 #include "hemi/table.h"
-#include "hemi/launch.h"
+//#include "hemi/launch.h"
 #include "hemi/parallel_for.h"
 #include "hemi/device_api.h"
 
@@ -13,40 +14,89 @@ void lookup(const int n, float *val, const hemi::table3<float> lookupTable, cons
     });
 }
 
-inline int index(int x, int y, int z, int dx, int dy)
+float lookup_validate(const int n, hemi::Array<float> *output,
+		      const hemi::table3<float> lookupTable) 
 {
-  return x + dx * (y + dy*z);
+  hemi::Array<float> x_val(n);
+  hemi::Array<float> y_val(n);
+  hemi::Array<float> z_val(n);
+  
+  //std::srand(0);
+  
+  for (int i = 0; i < n; ++i) {
+    x_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[0]-1) / (float)(lookupTable.inv_cell_size[0]));
+    y_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[1]-1) / (float)(lookupTable.inv_cell_size[1]));
+    z_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[2]-1) / (float)(lookupTable.inv_cell_size[2]));
+    //printf("random sample %i = [%f, %f, %f]\n", i, x_val.readOnlyHostPtr()[i], y_val.readOnlyHostPtr()[i], z_val.readOnlyHostPtr()[i]);
+  }
+
+  float *dev_ptr = output->writeOnlyDevicePtr();
+  const float *x_ptr = x_val.readOnlyDevicePtr();
+  const float *y_ptr = y_val.readOnlyDevicePtr();
+  const float *z_ptr = z_val.readOnlyDevicePtr();
+
+  hemi::parallel_for(0, n, [=] HEMI_LAMBDA (int i) {
+      dev_ptr[i] = lookupTable.lookup(x_ptr[i], y_ptr[i], z_ptr[i]);
+      //if (i == 5000) {
+      //printf("GPU %i %f\n", i, dev_ptr[i]);
+	//printf("GPU element %i %f\n", 0, lookupTable.getElement(1,0,0));
+	// }
+    });
+  
+  for (int i = 0; i < n; ++i) {
+    float value = lookupTable.lookup(x_val.readOnlyHostPtr()[i],
+				     y_val.readOnlyHostPtr()[i],
+				     z_val.readOnlyHostPtr()[i]);
+    // if (i == 5000) {
+    //printf("CPU %i %f [%f,%f,%f]\n", i, value, x_val.readOnlyHostPtr()[i], y_val.readOnlyHostPtr()[i], z_val.readOnlyHostPtr()[i]);
+      //printf("CPU element %i %f\n", 0, lookupTable.getElement(2,5,1));
+      // }
+    output->hostPtr()[i] -= value;
+    output->hostPtr()[i] /= value;
+  }
+
+  float average = 0.0f;
+  for (int i = 0; i < n; ++i) {
+    average += output->hostPtr()[i];
+  }
+
+  average /= (float)n;
+  return average;
 }
 
 int main(void) {
-  const int n = 1000;
-  const int nx = 10, ny = 10, nz = 10;
+  std::srand(0);
+
+  const int n = 100;
+  const int nx = 25, ny = 25, nz = 25;
 
   float *table_array = new float[nx*ny*nz];
-
+  
   // lets make some test data
   for (int z = 0; z < nz; ++z)
     for (int y = 0; y < ny; ++y)
       for (int x = 0; x < nx; ++x)
-	table_array[hemi::index(x, y, z, nx, ny)] = 0.5f * x * y * z;
+	table_array[hemi::index(x, y, z, nx, ny)] = x;// + y + z;// (std::rand() * 1.0) / (float)RAND_MAX;
 
   hemi::Array<float> output(n);
   hemi::Table3D<float> lookup_table(table_array, 
 				    nx, ny, nz, 
 				    0.0, 0.0, 0.0,
-				    10000.0, 10000.0, 10000.0);
+				    100.0, 100.0, 100.0);
   
-  float *pointer;
+  /*  float *pointer;
 #ifndef HEMI_CUDA_DISABLE
   pointer = output.devicePtr();
 #else
   pointer = output.hostPtr();
-#endif
+  #endif*/
   
-  lookup(n, pointer, lookup_table.readOnlyTable(), 1530.35, 1000.23, 5010.0);
+  //lookup(n, pointer, lookup_table.readOnlyTable(), 1530.35, 1000.23, 5010.0);
   
-  printf("element 0 = %f\n", output.hostPtr()[0]);
+  //printf("element 0 = %f\n", output.hostPtr()[0]);
 
+  float precision = lookup_validate(n, &output, lookup_table.readOnlyTable());
+  printf("precision %f\n", precision);
   //delete [] table_array;
 
   return 0;

--- a/examples/simple/lookup_table.cpp
+++ b/examples/simple/lookup_table.cpp
@@ -4,6 +4,7 @@
 #include "hemi/array.h"
 #include "hemi/table.h"
 //#include "hemi/launch.h"
+#include "hemi/grid_stride_range.h"
 #include "hemi/parallel_for.h"
 #include "hemi/device_api.h"
 
@@ -14,50 +15,72 @@ void lookup(const int n, float *val, const hemi::table3<float> lookupTable, cons
     });
 }
 
-float lookup_validate(const int n, hemi::Array<float> *output,
-		      const hemi::table3<float> lookupTable) 
+HEMI_LAUNCHABLE void lookup_kernel(const int n, float *output, const hemi::table3<float> lookupTable, const float *x, const float *y, const float *z)
 {
+  for (auto i : hemi::grid_stride_range(0, n)) {
+    output[i] = lookupTable.lookup(x[i], y[i], z[i]);
+  }
+}
+
+float lookup_validate(const int n, const hemi::table3<float> lookupTable) 
+{
+  hemi::Array<float> output_gpu(n);
+  hemi::Array<float> output_cpu(n);
+
   hemi::Array<float> x_val(n);
   hemi::Array<float> y_val(n);
   hemi::Array<float> z_val(n);
   
-  //std::srand(0);
-  
   for (int i = 0; i < n; ++i) {
-    x_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[0]-1) / (float)(lookupTable.inv_cell_size[0]));
-    y_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[1]-1) / (float)(lookupTable.inv_cell_size[1]));
-    z_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[2]-1) / (float)(lookupTable.inv_cell_size[2]));
-    //printf("random sample %i = [%f, %f, %f]\n", i, x_val.readOnlyHostPtr()[i], y_val.readOnlyHostPtr()[i], z_val.readOnlyHostPtr()[i]);
+    x_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[0]-1) / (float)(lookupTable.reciprocal_cell_size[0]));
+    y_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[1]-1) / (float)(lookupTable.reciprocal_cell_size[1]));
+    z_val.writeOnlyHostPtr()[i] = (std::rand() / (float)RAND_MAX) * ( (lookupTable.size[2]-1) / (float)(lookupTable.reciprocal_cell_size[2]));
   }
 
-  float *dev_ptr = output->writeOnlyDevicePtr();
+  float *dev_ptr = output_gpu.writeOnlyDevicePtr();
   const float *x_ptr = x_val.readOnlyDevicePtr();
   const float *y_ptr = y_val.readOnlyDevicePtr();
   const float *z_ptr = z_val.readOnlyDevicePtr();
 
-  hemi::parallel_for(0, n, [=] HEMI_LAMBDA (int i) {
+  // calculate GPU interpolations
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+  cudaEventRecord(start);
+
+  /*hemi::parallel_for(0, n, [lookupTable, x_ptr, y_ptr, z_ptr, dev_ptr] HEMI_LAMBDA (int i) {
       dev_ptr[i] = lookupTable.lookup(x_ptr[i], y_ptr[i], z_ptr[i]);
-      //if (i == 5000) {
-      //printf("GPU %i %f\n", i, dev_ptr[i]);
-	//printf("GPU element %i %f\n", 0, lookupTable.getElement(1,0,0));
-	// }
-    });
+      });*/
+  hemi::cudaLaunch(lookup_kernel, n, output_gpu.writeOnlyDevicePtr(), lookupTable, x_ptr, y_ptr, z_ptr);
+
+  cudaEventRecord(stop);
+  cudaEventSynchronize(stop);
+  float milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  printf("Time for %i lookups on GPU was %f ms\n", n, milliseconds);
+
+  
+  // compare to CPU result
+  cudaEvent_t start2, stop2;
+  cudaEventCreate(&start2);
+  cudaEventCreate(&stop2);
+  cudaEventRecord(start2);
   
   for (int i = 0; i < n; ++i) {
-    float value = lookupTable.lookup(x_val.readOnlyHostPtr()[i],
-				     y_val.readOnlyHostPtr()[i],
-				     z_val.readOnlyHostPtr()[i]);
-    // if (i == 5000) {
-    //printf("CPU %i %f [%f,%f,%f]\n", i, value, x_val.readOnlyHostPtr()[i], y_val.readOnlyHostPtr()[i], z_val.readOnlyHostPtr()[i]);
-      //printf("CPU element %i %f\n", 0, lookupTable.getElement(2,5,1));
-      // }
-    output->hostPtr()[i] -= value;
-    output->hostPtr()[i] /= value;
+    output_cpu.hostPtr()[i] = lookupTable.lookup(x_val.readOnlyHostPtr()[i],
+						 y_val.readOnlyHostPtr()[i],
+						 z_val.readOnlyHostPtr()[i]);
   }
 
-  float average = 0.0f;
+  cudaEventRecord(stop2);
+  cudaEventSynchronize(stop2);
+  milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start2, stop2);
+  printf("Time for %i lookups on CPU was %f ms\n", n, milliseconds);
+  
+  float average = 0;
   for (int i = 0; i < n; ++i) {
-    average += output->hostPtr()[i];
+    average += (output_gpu.hostPtr()[i] - output_cpu.hostPtr()[i]) / output_cpu.hostPtr()[i];
   }
 
   average /= (float)n;
@@ -67,23 +90,20 @@ float lookup_validate(const int n, hemi::Array<float> *output,
 int main(void) {
   std::srand(0);
 
-  const int n = 100;
-  const int nx = 25, ny = 25, nz = 25;
-
-  float *table_array = new float[nx*ny*nz];
-  
-  // lets make some test data
-  for (int z = 0; z < nz; ++z)
-    for (int y = 0; y < ny; ++y)
-      for (int x = 0; x < nx; ++x)
-	table_array[hemi::index(x, y, z, nx, ny)] = x;// + y + z;// (std::rand() * 1.0) / (float)RAND_MAX;
+  const int n = 1000000;
+  const int nx = 100, ny = 100, nz = 100;
 
   hemi::Array<float> output(n);
-  hemi::Table3D<float> lookup_table(table_array, 
-				    nx, ny, nz, 
+  hemi::Table3D<float> lookup_table(nx, ny, nz, 
 				    0.0, 0.0, 0.0,
 				    100.0, 100.0, 100.0);
   
+  // lets make some test data                                                                                              
+  for (int z = 0; z < nz; ++z)
+    for (int y = 0; y < ny; ++y)
+      for (int x = 0; x < nx; ++x)
+        lookup_table.writeOnlyHostPtr()[hemi::index(x, y, z, nx, ny)] = std::rand() / (float)RAND_MAX;
+
   /*  float *pointer;
 #ifndef HEMI_CUDA_DISABLE
   pointer = output.devicePtr();
@@ -95,7 +115,7 @@ int main(void) {
   
   //printf("element 0 = %f\n", output.hostPtr()[0]);
 
-  float precision = lookup_validate(n, &output, lookup_table.readOnlyTable());
+  float precision = lookup_validate(n, lookup_table.readOnlyTable());
   printf("precision %f\n", precision);
   //delete [] table_array;
 

--- a/examples/simple/lookup_table.cpp
+++ b/examples/simple/lookup_table.cpp
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include "hemi/hemi.h"
+#include "hemi/table.h"
+#include "hemi/launch.h"
+#include "hemi/device_api.h"
+
+int main(void) {
+
+  hemi::Table3D<float> lookup_table(5, 5, 5);
+  
+  return 0;
+}

--- a/examples/simple/lookup_table.cpp
+++ b/examples/simple/lookup_table.cpp
@@ -8,8 +8,8 @@
 
 void lookup(const int n, float *val, const hemi::table3D<float> lookupTable, const float x, const float y, const float z)
 {
-  hemi::parallel_for(0, n, [&] HEMI_LAMBDA (int i) {
-      val[i] = lookupTable.lookup(1.0, 1.0, 1.0);
+  hemi::parallel_for(0, n, [=] HEMI_LAMBDA (int i) {
+      val[i] = lookupTable.lookup(x, y, z);
     });
 }
 
@@ -29,20 +29,13 @@ int main(void) {
   for (int z = 0; z < nz; ++z)
     for (int y = 0; y < ny; ++y)
       for (int x = 0; x < nx; ++x)
-	table_array[hemi::index(x,y,z,nx,ny)] = 0.5f;
+	table_array[hemi::index(x, y, z, nx, ny)] = 0.5f;
 
   hemi::Array<float> output(n);
   hemi::Table3D<float> lookup_table(nx, ny, nz, table_array);
   
-  //hemi::table3D<float> honk;
-  //printf("%f", honk.lookup(1,1,1));
-
-  //const hemi::table3D<float> tbl = lookup_table.readOnlyTable();
-  //printf("%f/n", tbl.lookup(1.0, 1.0, 1.0));
+  lookup(n, output.devicePtr(), lookup_table.readOnlyTable(), 2.5, 2.5, 2.5);
   
-  //printf("%f", lookup_table.readOnlyTable().lookup(1,1,1));
-  
-  lookup(n, output.hostPtr(), lookup_table.readOnlyTable(), 2.5, 2.5, 2.5);
   printf("element 0 = %f\n", output.hostPtr()[0]);
 
   //delete [] table_array;

--- a/hemi/table.h
+++ b/hemi/table.h
@@ -67,6 +67,7 @@ namespace hemi {
 #ifdef HEMI_DEV_CODE
 	return tex3D<T>(texture, xd + 0.5f, yd + 0.5f, zd + 0.5f);
 #else
+	// Implementation of: https://en.wikipedia.org/wiki/Trilinear_interpolation
 	int ubx = (int)xd;
 	int uby = (int)yd;
 	int ubz = (int)zd;
@@ -75,9 +76,9 @@ namespace hemi {
 	int oby = uby + 1;
 	int obz = ubz + 1;
 
-	xd -= std::floor(ubx);
-	yd -= std::floor(uby);
-	zd -= std::floor(ubz);
+	xd -= (float)(ubx);
+	yd -= (float)(uby);
+	zd -= (float)(ubz);
 
 	float i1 = hPtr[hemi::index(ubx, uby, ubz, size[0], size[1])] * (1.0f - zd) 
 	  + hPtr[hemi::index(ubx, uby, obz, size[0], size[1])] * zd;

--- a/hemi/table.h
+++ b/hemi/table.h
@@ -1,0 +1,172 @@
+///////////////////////////////////////////////////////////////////////////////
+// 
+// "Hemi" CUDA Portable C/C++ Utilities
+// 
+// Copyright 2012-2015 NVIDIA Corporation
+//
+// License: BSD License, see LICENSE file in Hemi home directory
+//
+// The home for Hemi is https://github.com/harrism/hemi
+//
+///////////////////////////////////////////////////////////////////////////////
+// Please see the file README.md (https://github.com/harrism/hemi/README.md) 
+// for full documentation and discussion.
+///////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "hemi/hemi.h"
+#include <cstring>
+#include <type_traits> 
+
+#ifndef HEMI_ARRAY_DEFAULT_LOCATION
+  #ifdef HEMI_CUDA_COMPILER
+    #define HEMI_ARRAY_DEFAULT_LOCATION hemi::device
+  #else
+    #define HEMI_ARRAY_DEFAULT_LOCATION hemi::host
+  #endif
+#endif
+
+namespace hemi {
+
+	//template <typename T> class Table1D; // forward decl
+	//template <typename T> class Table2D; // forward decl
+	template <typename T> class Table3D; // forward decl
+
+	enum Location {
+        host   = 0,
+        device = 1
+    };
+
+    template <typename T>
+    class Table3D 
+    {
+    public:
+    	Table3D(size_t nx, size_t ny, size_t nz) :
+    	nSize(nx * ny * nz);
+    	nSizeX(nx);
+    	nSizeY(ny);
+    	nSizeZ(nz);
+    	{	
+    	}
+
+    private:
+    	size_t nSize;
+    	size_t nSizeX;
+    	size_t nSizeY;
+    	size_t nSizeZ;
+
+    	mutable T *hPtr;
+    	cudaArray *dPtr;
+        
+		cudaMemcpy3DParms copyParams;
+		cudaExtent volumeSize;
+		cudaTextureObject_t tex;
+
+        mutable bool    isHostAlloced;
+        mutable bool    isDeviceAlloced;        
+
+        mutable bool    isHostValid;
+        mutable bool    isDeviceValid;
+
+    protected:
+        void allocateHost() const
+        {
+            assert(!isHostAlloced);
+            hPtr = new T[nSize];    
+                
+            isHostAlloced = true;
+            isHostValid = false;
+        }
+
+    	void allocateDevice() const
+    	{
+#ifndef HEMI_CUDA_DISABLE
+    		assert(!isDeviceAlloced);
+    	    volumeSize = make_cudaExtent(nSizeX, nSizeY, nSizeZ);
+  			cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<T>();
+  			cudaMalloc3DArray(dPtr, &channelDesc, volumeSize);
+			copyParams.dstArray = dPtr;
+
+    	    isDeviceAlloced = true;
+            isDeviceValid = false;
+#endif
+    	}
+
+        void deallocateHost()
+        {
+            if (isHostAlloced) {
+                delete [] hPtr;
+                nSize = 0;
+                nSizeX = 0;
+                nSizeY = 0;
+                nSixeZ = 0;
+                isHostAlloced = false;
+                isHostValid   = false;
+            }
+        }
+
+        void deallocateDevice()
+        {
+#ifndef HEMI_CUDA_DISABLE
+            if (isDeviceAlloced) {
+                checkCuda( cudaFreeArray(dPtr) );
+                checkCuda( cudaDestroyTextureObject(tex) );
+                isDeviceAlloced = false;
+                isDeviceValid   = false;
+            }
+#endif
+        }
+
+        void copyHostToDevice() const
+        {
+#ifndef HEMI_CUDA_DISABLE
+            assert(isHostAlloced);
+            if (!isDeviceAlloced) allocateDevice();
+            copyParams.srcPtr = make_cudaPitchedPtr((void*)hPtr, volumeSize.width * sizeof(float), volumeSize.width, volumeSize.height);                                                                                                                                        
+  			copyParams.extent   = volumeSize;
+  			copyParams.kind     = cudaMemcpyHostToDevice;
+  			cudaMemcpy3D(&copyParams);
+
+  			// bind to texture
+  			struct cudaResourceDesc resDesc;
+  			memset(&resDesc, 0, sizeof(resDesc));
+  			resDesc.resType =  cudaResourceTypeArray;
+  			resDesc.res.linear.devPtr = dPtr;
+  			resDesc.res.linear.sizeInBytes = volumeSize.width * volumeSize.height * volumeSize.depth * sizeof(T);
+			resDesc.res.linear.desc.f = cudaChannelFormatKindFloat;
+ 			resDesc.res.linear.desc.x = sizeof(T) * 8;
+  			struct cudaTextureDesc texDesc;
+ 			memset(&texDesc, 0, sizeof(texDesc));
+ 			//texDesc.normalizedCoords = false;                                                                                                                                     
+ 			texDesc.normalizedCoords = true;
+ 			texDesc.readMode = cudaReadModeElementType;
+  			//texDesc.filterMode = cudaFilterModePoint;                                                                                                                             
+  			texDesc.filterMode = cudaFilterModeLinear;
+
+  			texDesc.addressMode[0] = cudaAddressModeClamp;
+ 			texDesc.addressMode[1] = cudaAddressModeClamp;
+ 			texDesc.addressMode[2] = cudaAddressModeClamp;
+
+ 			cudaCreateTextureObject(&tex, &resDesc, &texDesc, NULL);
+
+            isDeviceValid = true;
+#endif
+        }
+
+        void copyDeviceToHost() const
+        {
+/*#ifndef HEMI_CUDA_DISABLE
+            assert(isDeviceAlloced);
+            if (!isHostAlloced) allocateHost();
+            checkCuda( cudaMemcpy(hPtr, 
+                                  dPtr, 
+                                  nSize * sizeof(T), 
+                                  cudaMemcpyDeviceToHost) );
+            isHostValid = true;
+#endif*/
+        }
+
+    };
+
+
+}

--- a/hemi/table.h
+++ b/hemi/table.h
@@ -16,6 +16,7 @@
 
 #include "hemi/hemi.h"
 #include <cstring>
+#include <climits>
 #include <type_traits> 
 
 #ifndef HEMI_ARRAY_DEFAULT_LOCATION
@@ -216,7 +217,7 @@ namespace hemi {
 	resDesc.res.linear.devPtr = dPtr;
 	resDesc.res.linear.sizeInBytes = volumeSize.width * volumeSize.height * volumeSize.depth * sizeof(T);
 	resDesc.res.linear.desc.f = cudaChannelFormatKindFloat;
-	resDesc.res.linear.desc.x = sizeof(T) * 8;
+	resDesc.res.linear.desc.x = sizeof(T) * CHAR_BIT;
 	struct cudaTextureDesc texDesc;
 	memset(&texDesc, 0, sizeof(texDesc));
 	texDesc.normalizedCoords = true;

--- a/hemi/table.h
+++ b/hemi/table.h
@@ -20,16 +20,22 @@
 #include <climits>
 #include <type_traits> 
 
-#ifndef HEMI_ARRAY_DEFAULT_LOCATION
+/*#ifndef HEMI_ARRAY_DEFAULT_LOCATION
   #ifdef HEMI_CUDA_COMPILER
     #define HEMI_ARRAY_DEFAULT_LOCATION hemi::device
   #else
     #define HEMI_ARRAY_DEFAULT_LOCATION hemi::host
   #endif
-#endif
+  #endif*/
 
 namespace hemi {
 
+  /* flatten a 2D array index into 1D */
+  HEMI_DEV_CALLABLE_INLINE int index(const int x, const int y, const int dx) {
+    return x + dx * y;
+  }
+
+  /* flatten a 3D array index into 1D */
   HEMI_DEV_CALLABLE_INLINE int index(const int x, const int y, const int z, const int dx, const int dy) {
     return x + dx * (y + dy * z);
   }
@@ -38,54 +44,50 @@ namespace hemi {
   //template <typename T> class Table2D; // forward decl
   template <typename T> class Table3D; // forward decl
   
+  /* this is essentially a wrapper for cudaTextureObject, which should be passed by value to the kernel */
   template <typename T>
     struct table3 {      
+      /* look up element value, i.e. no interpolation between cells is applied */
       HEMI_DEV_CALLABLE_INLINE_MEMBER T getElement(const int i, const int j, const int k) const
       {
 #ifdef HEMI_DEV_CODE
-        return tex3D<T>(texture, (T)i + 0.5f, (T)j + 0.5f, (T)k + 0.5f);
+        return tex3D<T>(texture, (float)i + 0.5f, (float)j + 0.5f, (float)k + 0.5f);
 #else
 	return hPtr[hemi::index(i, j, k, size[0], size[1])];
 #endif
-	
       };
       
-      HEMI_DEV_CALLABLE_INLINE_MEMBER T lookup(const T x, const T y, const T z) const
+      /* lookup function, linearly interpolates between cells */
+      HEMI_DEV_CALLABLE_INLINE_MEMBER T lookup(const float x, const float y, const float z) const
       {
-#ifdef HEMI_DEV_CODE
-
-	T xd = 0.5 + (x - low_edge[0]) * ((size[0]-1) / (up_edge[0] - low_edge[0]));//inv_cell_size[0];
-	T yd = 0.5 + (y - low_edge[1]) * ((size[1]-1) / (up_edge[1] - low_edge[1]));//inv_cell_size[1];
-	T zd = 0.5 + (z - low_edge[2]) * ((size[2]-1) / (up_edge[2] - low_edge[2]));//inv_cell_size[2];
-
-	return tex3D<T>(texture, xd, yd, zd);
-#else
-	T xd = (x - low_edge[0]) * inv_cell_size[0];
-        T yd = (y - low_edge[1]) * inv_cell_size[1];
-        T zd = (z - low_edge[2]) * inv_cell_size[2];
+	float xd = (x - low_edge[0]) * reciprocal_cell_size[0];
+        float yd = (y - low_edge[1]) * reciprocal_cell_size[1];
+        float zd = (z - low_edge[2]) * reciprocal_cell_size[2];
 	
-	int ubx = (int)xd;//static_cast<int>(xd);
-	int uby = (int)yd;//static_cast<int>(yd);
-	int ubz = (int)zd;//static_cast<int>(zd);
+#ifdef HEMI_DEV_CODE
+	return tex3D<T>(texture, xd + 0.5f, yd + 0.5f, zd + 0.5f);
+#else
+	int ubx = (int)xd;
+	int uby = (int)yd;
+	int ubz = (int)zd;
 	
 	int obx = ubx + 1;
 	int oby = uby + 1;
 	int obz = ubz + 1;
-	
-	const float v[] = { hPtr[hemi::index(ubx, uby, ubz, size[0], size[1])], hPtr[hemi::index(ubx, uby, obz, size[0], size[1])],
-			    hPtr[hemi::index(ubx, oby, ubz, size[0], size[1])], hPtr[hemi::index(ubx, oby, obz, size[0], size[1])],
-			    hPtr[hemi::index(obx, uby, ubz, size[0], size[1])], hPtr[hemi::index(obx, uby, obz, size[0], size[1])],
-			    hPtr[hemi::index(obx, oby, ubz, size[0], size[1])], hPtr[hemi::index(obx, oby, obz, size[0], size[1])] };
-	
-	xd -= static_cast<float>(ubx);
-	yd -= static_cast<float>(uby);
-	zd -= static_cast<float>(ubz);
-  
-	float i1 = v[0] * (1.0f - zd) + v[1] * zd;
-	float i2 = v[2] * (1.0f - zd) + v[3] * zd;
-	float j1 = v[4] * (1.0f - zd) + v[5] * zd;
-	float j2 = v[6] * (1.0f - zd) + v[7] * zd;
-  
+
+	xd -= std::floor(ubx);
+	yd -= std::floor(uby);
+	zd -= std::floor(ubz);
+
+	float i1 = hPtr[hemi::index(ubx, uby, ubz, size[0], size[1])] * (1.0f - zd) 
+	  + hPtr[hemi::index(ubx, uby, obz, size[0], size[1])] * zd;
+        float i2 = hPtr[hemi::index(ubx, oby, ubz, size[0], size[1])] * (1.0f - zd) 
+	  + hPtr[hemi::index(ubx, oby, obz, size[0], size[1])] * zd;
+        float j1 = hPtr[hemi::index(obx, uby, ubz, size[0], size[1])] * (1.0f - zd) 
+	  + hPtr[hemi::index(obx, uby, obz, size[0], size[1])] * zd;
+	float j2 = hPtr[hemi::index(obx, oby, ubz, size[0], size[1])] * (1.0f - zd) 
+	  + hPtr[hemi::index(obx, oby, obz, size[0], size[1])] * zd;
+
 	float w1 = i1 * (1.0f - yd) + i2 * yd;
 	float w2 = j1 * (1.0f - yd) + j2 * yd;
 
@@ -100,22 +102,53 @@ namespace hemi {
       
       int size[3];
       float low_edge[3];
-      float up_edge[3];
-      float inv_cell_size[3];
+      float reciprocal_cell_size[3];
     };
   
   template <typename T>
     class Table3D 
     {
     public:
+      Table3D(size_t nx, size_t ny, size_t nz,
+	      float low_edge_x, float low_edge_y, float low_edge_z,
+	      float up_edge_x, float up_edge_y, float up_edge_z) 
+	{
+	  _table.size[0] = nx;
+	  _table.size[1] = ny;
+	  _table.size[2] = nz;
+	  
+	  // set the table range                                                                                                                                        
+          _table.low_edge[0] = low_edge_x;
+          _table.low_edge[1] = low_edge_y;
+          _table.low_edge[2] = low_edge_z;
+
+	  // width of each cell                                                                                                   
+          _table.reciprocal_cell_size[0] = (nx-1) / static_cast<float>(up_edge_x - low_edge_x);
+          _table.reciprocal_cell_size[1] = (ny-1) / static_cast<float>(up_edge_y - low_edge_y);
+          _table.reciprocal_cell_size[2] = (nz-1) / static_cast<float>(up_edge_z - low_edge_z);
+
+	  normalized_coords = false;
+	  isHostAlloced = false;
+	  isDeviceAlloced = false;
+	  isHostValid = false;
+	  isDeviceValid = false;
+	  isForeignHostPtr = false;
+
+	  allocateHost();
+
+#ifndef HEMI_CUDA_DISABLE
+	  allocateDevice();
+#endif
+	}
+
     Table3D(T *data,
 	    size_t nx, size_t ny, size_t nz,
 	    float low_edge_x, float low_edge_y, float low_edge_z,
-	    float up_edge_x, float up_edge_y, float up_edge_z) :
+	    float up_edge_x, float up_edge_y, float up_edge_z) /*:
       nSize(nx * ny * nz),
 	nSizeX(nx),
 	nSizeY(ny),
-	nSizeZ(nz)
+	nSizeZ(nz)*/
 	{	
 	  // this is unsafe!
 	  _table.hPtr = data;
@@ -127,20 +160,23 @@ namespace hemi {
 	  _table.low_edge[0] = low_edge_x;
 	  _table.low_edge[1] = low_edge_y;
 	  _table.low_edge[2] = low_edge_z;
-	  _table.up_edge[0] = up_edge_x;
+	  /*_table.up_edge[0] = up_edge_x;
 	  _table.up_edge[1] = up_edge_y;
-          _table.up_edge[2] = up_edge_z;
+          _table.up_edge[2] = up_edge_z;*/
 
 	  // width of each cell
-	  _table.inv_cell_size[0] = (nx-1) / static_cast<float>(up_edge_x - low_edge_x);
-	  _table.inv_cell_size[1] = (ny-1) / static_cast<float>(up_edge_y - low_edge_y);
-          _table.inv_cell_size[2] = (nz-1) / static_cast<float>(up_edge_z - low_edge_z);
+	  _table.reciprocal_cell_size[0] = (nx-1) / static_cast<float>(up_edge_x - low_edge_x);
+	  _table.reciprocal_cell_size[1] = (ny-1) / static_cast<float>(up_edge_y - low_edge_y);
+          _table.reciprocal_cell_size[2] = (nz-1) / static_cast<float>(up_edge_z - low_edge_z);
 
+	  isForeignHostPtr = true;
 	  isHostAlloced = true;
 	  isHostValid = true;
 	  isDeviceAlloced = false;
 	  isDeviceValid = false;
-	  
+
+	  // no need for this as we are using a foreign pointer
+	  //allocateHost(); 
 #ifndef HEMI_CUDA_DISABLE
 	  allocateDevice();
 	  isDeviceAlloced = true;
@@ -155,16 +191,31 @@ namespace hemi {
 	  deallocateHost();
 	}
       
-      const table3<T> readOnlyTable() const
-	{
-	  return _table;
-	}
+      const table3<T> readOnlyTable()
+      {
+	/* try copying the struct to device too */
+#ifndef HEMI_CUDA_DISABLE
+	assert(isDeviceAlloced);
+	if (!isDeviceValid)
+	  copyHostToDevice();
+#endif
+	
+	return _table;
+      }
+
+      T* writeOnlyHostPtr()
+      {
+	if (!isHostAlloced) allocateHost();
+	isDeviceValid = false;
+	isHostValid   = true;
+	return _table.hPtr;
+      }
       
     private:
-      size_t nSize;
+      /*size_t nSize;
       size_t nSizeX;
       size_t nSizeY;
-      size_t nSizeZ;
+      size_t nSizeZ;*/
       
 #ifndef HEMI_CUDA_DISABLE
       cudaArray_t dPtr;
@@ -172,6 +223,8 @@ namespace hemi {
 #endif
       table3<T> _table;
       
+      bool            isForeignHostPtr;
+
       mutable bool    isHostAlloced;
       mutable bool    isDeviceAlloced;        
       
@@ -184,7 +237,8 @@ namespace hemi {
       void allocateHost() const
       {
 	assert(!isHostAlloced);
-	_table.hPtr = new T[nSize];    
+	
+	_table.hPtr = new T[_table.size[0] * _table.size[1] * _table.size[2]];    
 	
 	isHostAlloced = true;
 	isHostValid = false;
@@ -194,7 +248,7 @@ namespace hemi {
       {
 #ifndef HEMI_CUDA_DISABLE
 	assert(!isDeviceAlloced);
-	volumeSize = make_cudaExtent(nSizeX, nSizeY, nSizeZ);
+	volumeSize = make_cudaExtent(_table.size[0], _table.size[1], _table.size[2]);
 	cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<T>();
 	checkCuda( cudaMalloc3DArray(&dPtr, &channelDesc, volumeSize) );
 	
@@ -206,11 +260,9 @@ namespace hemi {
       void deallocateHost()
       {
 	if (isHostAlloced) {
-	  //delete [] _table.hPtr;
-	  nSize  = 0;
-	  nSizeX = 0;
-	  nSizeY = 0;
-	  nSizeZ = 0;
+	  if (!isForeignHostPtr)
+	    delete [] _table.hPtr;
+
 	  isHostAlloced = false;
 	  isHostValid   = false;
 	}

--- a/hemi/table.h
+++ b/hemi/table.h
@@ -32,6 +32,10 @@ namespace hemi {
 	//template <typename T> class Table2D; // forward decl
 	template <typename T> class Table3D; // forward decl
 
+	// move these typedefs to hemi.h maybe
+	// http://tipsandtricks.runicsoft.com/Cpp/MemberFunctionPointers.html
+	typedef float ( hemi::Table3D::*table ) (float, float, float);
+
 	enum Location {
         host   = 0,
         device = 1
@@ -47,6 +51,24 @@ namespace hemi {
     	nSizeY(ny);
     	nSizeZ(nz);
     	{	
+    	}
+
+    	~Table3D()
+    	{
+    		deallocateDevice();
+            deallocateHost();
+    	}
+
+    	table GetTable(T x, T y, T z)
+    	{
+    		// notice the typedef
+    		table tbl;
+#ifdef HEMI_DEV_CODE
+    		tbl = &hemi::Table3D::dEval;
+#else
+    		tbl = &hemi::Table3D::hEval;
+#endif
+    		return tbl;
     	}
 
     private:

--- a/hemi/table.h
+++ b/hemi/table.h
@@ -28,176 +28,222 @@
 
 namespace hemi {
 
-	//template <typename T> class Table1D; // forward decl
-	//template <typename T> class Table2D; // forward decl
-	template <typename T> class Table3D; // forward decl
+  inline int index(int x, int y, int z, int dx, int dy)
+  {
+    return x + dx * (y + dy*z);
+  }
 
-    // EDIT: this idea wont work!
-	// move these typedefs to hemi.h maybe.
-	// http://tipsandtricks.runicsoft.com/Cpp/MemberFunctionPointers.html
-	//typedef float ( hemi::Table3D::*table ) (float, float, float);
-
-	template <typename T>
-	  struct table3D {
-
-	    HEMI_DEV_CALLABLE_INLINE_MEMBER T lookup(const T x, const T y, const T z) const
-	    {
+  
+  //template <typename T> class Table1D; // forward decl
+  //template <typename T> class Table2D; // forward decl
+  template <typename T> class Table3D; // forward decl
+  
+  // EDIT: this idea wont work!
+  // move these typedefs to hemi.h maybe.
+  // http://tipsandtricks.runicsoft.com/Cpp/MemberFunctionPointers.html
+  //typedef float ( hemi::Table3D::*table ) (float, float, float);
+  
+  template <typename T>
+    struct table3D {
+      
+      HEMI_DEV_CALLABLE_INLINE_MEMBER T lookup(const T x, const T y, const T z) const
+      {
 #ifdef HEMI_DEV_CODE
-	      return tex3D<T>(texture, x ,y ,z);
+	return tex3D<T>(texture, x, y, z);
 #else
-	      return 1.0;
+	T xd = x;//(x - xbound[0]) * inv_cell_size[0];
+	T yd = y;// (y - ybound[0]) * inv_cell_size[1];
+	T zd = z;//(z - zbound[0]) * inv_cell_size[2];
+
+	int ubx = static_cast<int>(xd);
+	int uby = static_cast<int>(yd);
+	int ubz = static_cast<int>(zd);
+
+	int obx = ubx + 1;
+	int oby = uby + 1;
+	int obz = ubz + 1;
+
+	const T v[] = { hPtr[hemi::index(ubx, uby, ubz, sizeX, sizeY)], hPtr[hemi::index(ubx, uby, obz, sizeX, sizeY)],
+			hPtr[hemi::index(ubx, oby, ubz, sizeX, sizeY)], hPtr[hemi::index(ubx, oby, obz, sizeX, sizeY)],
+			hPtr[hemi::index(obx, uby, ubz, sizeX, sizeY)], hPtr[hemi::index(obx, uby, obz, sizeX, sizeY)],
+			hPtr[hemi::index(obx, oby, ubz, sizeX, sizeY)], hPtr[hemi::index(obx, oby, obz, sizeX, sizeY)] };
+	
+	xd -= (float)ubx;
+	yd -= (float)uby;
+	zd -= (float)ubz;
+  
+	float i1 = v[0] * (1 - zd) + v[1] * zd;
+	float i2 = v[2] * (1 - zd) + v[3] * zd;
+	float j1 = v[4] * (1 - zd) + v[5] * zd;
+	float j2 = v[6] * (1 - zd) + v[7] * zd;
+  
+	float w1 = i1 * (1 - yd) + i2 * yd;
+	float w2 = j1 * (1 - yd) + j2 * yd;
+
+	float result = w1 * (1 - xd) + w2 * xd;
+	return result;
 #endif
-	    };
-
-	    #ifndef HEMI_CUDA_DISABLE
-	    cudaTextureObject_t texture;
-	    #endif
-	    mutable T *hPtr;
-	  };
-
-	enum Location {
-        host   = 0,
-        device = 1
+      };
+      
+#ifndef HEMI_CUDA_DISABLE
+      cudaTextureObject_t texture;
+#endif
+      mutable T *hPtr;
+      int sizeX;
+      int sizeY; 
+      int sizeZ;
     };
-
-    template <typename T>
+  
+  // already declared in array.h
+  /*enum Location {
+    host   = 0,
+    device = 1
+    };*/
+  
+  template <typename T>
     class Table3D 
     {
     public:
-    	Table3D(size_t nx, size_t ny, size_t nz) :
-    	nSize(nx * ny * nz);
-    	nSizeX(nx);
-    	nSizeY(ny);
-    	nSizeZ(nz);
-    	{	
-    	}
+    Table3D(size_t nx, size_t ny, size_t nz, T *data) :
+      nSize(nx * ny * nz),
+	nSizeX(nx),
+	nSizeY(ny),
+	nSizeZ(nz)
+	{	
+	  // this is unsafe!
+	  _table.hPtr = data;
+	  _table.sizeX = nx;
+	  _table.sizeY = ny;
+	  _table.sizeZ = nz;
 
-    	~Table3D()
-    	{
-    		deallocateDevice();
-            deallocateHost();
-    	}
-
-    	table getTable() const
-    	{
+	  isHostAlloced = true;
+	}
+      
+      ~Table3D()
+	{
+	  deallocateDevice();
+	  deallocateHost();
+	}
+      
+      const table3D<T> readOnlyTable() const
+	{
 	  return _table;
-    	}
-
+	}
+      
     private:
-    	size_t nSize;
-    	size_t nSizeX;
-    	size_t nSizeY;
-    	size_t nSizeZ;
-
-    	cudaArray *dPtr;
-        
-	cudaMemcpy3DParms copyParams;
-	cudaExtent volumeSize;
-	table _table;
-
-        mutable bool    isHostAlloced;
-        mutable bool    isDeviceAlloced;        
-
-        mutable bool    isHostValid;
-        mutable bool    isDeviceValid;
-
+      size_t nSize;
+      size_t nSizeX;
+      size_t nSizeY;
+      size_t nSizeZ;
+      
+#ifndef HEMI_CUDA_DISABLE
+      cudaArray *dPtr;
+      
+      cudaMemcpy3DParms copyParams;
+      cudaExtent volumeSize;
+#endif
+      table3D<T> _table;
+      
+      mutable bool    isHostAlloced;
+      mutable bool    isDeviceAlloced;        
+      
+      mutable bool    isHostValid;
+      mutable bool    isDeviceValid;
+      
     protected:
-        void allocateHost() const
-        {
-            assert(!isHostAlloced);
-            _table.hPtr = new T[nSize];    
-                
-            isHostAlloced = true;
-            isHostValid = false;
-        }
-
-    	void allocateDevice() const
-    	{
+      void allocateHost() const
+      {
+	assert(!isHostAlloced);
+	_table.hPtr = new T[nSize];    
+	
+	isHostAlloced = true;
+	isHostValid = false;
+      }
+      
+      void allocateDevice() const
+      {
 #ifndef HEMI_CUDA_DISABLE
-    		assert(!isDeviceAlloced);
-    	    volumeSize = make_cudaExtent(nSizeX, nSizeY, nSizeZ);
-  			cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<T>();
-  			cudaMalloc3DArray(dPtr, &channelDesc, volumeSize);
-			copyParams.dstArray = dPtr;
-
-    	    isDeviceAlloced = true;
-            isDeviceValid = false;
+	assert(!isDeviceAlloced);
+	volumeSize = make_cudaExtent(nSizeX, nSizeY, nSizeZ);
+	cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<T>();
+	cudaMalloc3DArray(dPtr, &channelDesc, volumeSize);
+	copyParams.dstArray = dPtr;
+	
+	isDeviceAlloced = true;
+	isDeviceValid = false;
 #endif
-    	}
-
-        void deallocateHost()
-        {
-            if (isHostAlloced) {
-                delete [] _table.hPtr;
-                nSize = 0;
-                nSizeX = 0;
-                nSizeY = 0;
-                nSixeZ = 0;
-                isHostAlloced = false;
-                isHostValid   = false;
-            }
-        }
-
-        void deallocateDevice()
-        {
+      }
+      
+      void deallocateHost()
+      {
+	if (isHostAlloced) {
+	  delete [] _table.hPtr;
+	  nSize = 0;
+	  nSizeX = 0;
+	  nSizeY = 0;
+	  nSizeZ = 0;
+	  isHostAlloced = false;
+	  isHostValid   = false;
+	}
+      }
+      
+      void deallocateDevice()
+      {
 #ifndef HEMI_CUDA_DISABLE
-            if (isDeviceAlloced) {
-                checkCuda( cudaFreeArray(dPtr) );
-                checkCuda( cudaDestroyTextureObject(_table.texture) );
-                isDeviceAlloced = false;
-                isDeviceValid   = false;
-            }
+	if (isDeviceAlloced) {
+	  checkCuda( cudaFreeArray(dPtr) );
+	  checkCuda( cudaDestroyTextureObject(_table.texture) );
+	  isDeviceAlloced = false;
+	  isDeviceValid   = false;
+	}
 #endif
-        }
-
-        void copyHostToDevice() const
-        {
+      }
+      
+      void copyHostToDevice() const
+      {
 #ifndef HEMI_CUDA_DISABLE
-            assert(isHostAlloced);
-            if (!isDeviceAlloced) allocateDevice();
-            copyParams.srcPtr = make_cudaPitchedPtr((void*)_table.hPtr, volumeSize.width * sizeof(float), volumeSize.width, volumeSize.height);
-	    copyParams.extent   = volumeSize;
-	    copyParams.kind     = cudaMemcpyHostToDevice;
-	    cudaMemcpy3D(&copyParams);
-	    
-	    // bind to texture
-	    struct cudaResourceDesc resDesc;
-	    memset(&resDesc, 0, sizeof(resDesc));
-	    resDesc.resType =  cudaResourceTypeArray;
-	    resDesc.res.linear.devPtr = dPtr;
-	    resDesc.res.linear.sizeInBytes = volumeSize.width * volumeSize.height * volumeSize.depth * sizeof(T);
-	    resDesc.res.linear.desc.f = cudaChannelFormatKindFloat;
-	    resDesc.res.linear.desc.x = sizeof(T) * 8;
-	    struct cudaTextureDesc texDesc;
-	    memset(&texDesc, 0, sizeof(texDesc));
-	    texDesc.normalizedCoords = true;
-	    texDesc.readMode = cudaReadModeElementType;
-	    texDesc.filterMode = cudaFilterModeLinear;
-	    
-	    texDesc.addressMode[0] = cudaAddressModeClamp;
-	    texDesc.addressMode[1] = cudaAddressModeClamp;
-	    texDesc.addressMode[2] = cudaAddressModeClamp;
-	    
-	    cudaCreateTextureObject(&_table.texture, &resDesc, &texDesc, NULL);
-	    
-            isDeviceValid = true;
+	assert(isHostAlloced);
+	if (!isDeviceAlloced) allocateDevice();
+	copyParams.srcPtr = make_cudaPitchedPtr((void*)_table.hPtr, volumeSize.width * sizeof(float), volumeSize.width, volumeSize.height);
+	copyParams.extent   = volumeSize;
+	copyParams.kind     = cudaMemcpyHostToDevice;
+	cudaMemcpy3D(&copyParams);
+	
+	// bind to texture
+	struct cudaResourceDesc resDesc;
+	memset(&resDesc, 0, sizeof(resDesc));
+	resDesc.resType =  cudaResourceTypeArray;
+	resDesc.res.linear.devPtr = dPtr;
+	resDesc.res.linear.sizeInBytes = volumeSize.width * volumeSize.height * volumeSize.depth * sizeof(T);
+	resDesc.res.linear.desc.f = cudaChannelFormatKindFloat;
+	resDesc.res.linear.desc.x = sizeof(T) * 8;
+	struct cudaTextureDesc texDesc;
+	memset(&texDesc, 0, sizeof(texDesc));
+	texDesc.normalizedCoords = true;
+	texDesc.readMode = cudaReadModeElementType;
+	texDesc.filterMode = cudaFilterModeLinear;
+	
+	texDesc.addressMode[0] = cudaAddressModeClamp;
+	texDesc.addressMode[1] = cudaAddressModeClamp;
+	texDesc.addressMode[2] = cudaAddressModeClamp;
+	
+	cudaCreateTextureObject(&_table.texture, &resDesc, &texDesc, NULL);
+	
+	isDeviceValid = true;
 #endif
-        }
-
-        void copyDeviceToHost() const
-        {
-/*#ifndef HEMI_CUDA_DISABLE
-            assert(isDeviceAlloced);
-            if (!isHostAlloced) allocateHost();
-            checkCuda( cudaMemcpy(hPtr, 
-                                  dPtr, 
-                                  nSize * sizeof(T), 
-                                  cudaMemcpyDeviceToHost) );
-            isHostValid = true;
-#endif*/
-        }
-
+      }
+      
+      void copyDeviceToHost() const
+      {
+	/*#ifndef HEMI_CUDA_DISABLE
+	  assert(isDeviceAlloced);
+	  if (!isHostAlloced) allocateHost();
+	  checkCuda( cudaMemcpy(hPtr, 
+	  dPtr, 
+	  nSize * sizeof(T), 
+	  cudaMemcpyDeviceToHost) );
+	  isHostValid = true;
+	  #endif*/
+      }
     };
-
-
 }


### PR DESCRIPTION
Lookup class `hemi::Table3D<T>` that creates an interface to a look-up table structure, using texture memory on GPU. Trilinear interpolation is implemented on CPU, and agrees to 5/6 decimal places when compared to the texture memory results.

The user calls `readOnlyDevicePtr()` to return a pointer to the struct object `hemi::table3<T>` that can be passed to the kernel. The similarity of `Table3D<T>` and `table3<t>` bothers me slightly so a better naming convention would be appreciated. The interpolation can then be performed by `lookup_struct->lookup(x, y, z)` both in a CUDA kernel and in host code. The device code is ~20 times faster when performing millions of interpolations.

The current implementation is only for 3D LUTs, but it is straightforward to create 1D and 2D versions. There are also other limitations such as read-only access, but this could be improved on with surface objects. Also, the CPU implementation has no out-of-bounds array checking, for speed reasons. This could be changed. 

See the two example programs added in /hemi/examples/simple
